### PR TITLE
Provide configuration option to use H2's Automatic Mixed Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,25 @@
 target
 work
+
+#Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion
+*.iml
+## Directory-based project format:
+#.idea/
+# if you remove the above rule, at least ignore the following:
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+#Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+## File-based project format:
+*.ipr
+*.iws
+## Plugin-specific files:
+# IntelliJ
+/out/
+.idea/libraries/*

--- a/src/main/java/org/jenkinsci/plugins/database/h2/PerItemH2Database.java
+++ b/src/main/java/org/jenkinsci/plugins/database/h2/PerItemH2Database.java
@@ -1,42 +1,49 @@
 package org.jenkinsci.plugins.database.h2;
 
 import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.TopLevelItem;
+
+import java.io.File;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.WeakHashMap;
 import javax.sql.DataSource;
+
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import org.h2.Driver;
-import org.jenkinsci.plugins.database.BasicDataSource2;
-import org.jenkinsci.plugins.database.PerItemDatabase;
-import org.jenkinsci.plugins.database.PerItemDatabaseDescriptor;
+import org.jenkinsci.plugins.database.*;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class PerItemH2Database extends PerItemDatabase  {
-    
+public class PerItemH2Database extends PerItemDatabase {
+
     // XXX should also discard entry if ItemListener.onDeleted/Renamed
-    private transient Map<TopLevelItem,DataSource> sources;
+    private transient Map<TopLevelItem, DataSource> sources;
 
     private final boolean autoServer;
 
-    @DataBoundConstructor public PerItemH2Database(boolean autoServer) {
+    @DataBoundConstructor
+    public PerItemH2Database(boolean autoServer) {
         this.autoServer = autoServer;
     }
 
-    public boolean getAutoServer(){
+    public boolean getAutoServer() {
         return this.autoServer;
     }
 
-    @Override public DataSource getDataSource(TopLevelItem item) throws SQLException {
+    @Override
+    public DataSource getDataSource(TopLevelItem item) throws SQLException {
         if (sources == null) {
-            sources = new WeakHashMap<TopLevelItem,DataSource>();
+            sources = new WeakHashMap<TopLevelItem, DataSource>();
         }
         DataSource source = sources.get(item);
         if (source == null) {
             BasicDataSource2 fac = new BasicDataSource2();
             fac.setDriverClass(Driver.class);
             String url = "jdbc:h2:" + item.getRootDir().toURI() + "data";
-            if(this.autoServer){
+            if (this.autoServer) {
                 url += ";AUTO_SERVER=true";
             }
             fac.setUrl(url);
@@ -46,12 +53,24 @@ public class PerItemH2Database extends PerItemDatabase  {
         return source;
     }
 
-    @Extension public static class DescriptorImpl extends PerItemDatabaseDescriptor {
+    @Extension
+    public static class DescriptorImpl extends PerItemDatabaseDescriptor {
 
-        @Override public String getDisplayName() {
+        @Override
+        public String getDisplayName() {
             return "Embedded local database (H2)";
         }
 
+    }
+
+    @Initializer(after = InitMilestone.PLUGINS_STARTED)
+    public static void setDefaultPerItemDatabase() {
+        Jenkins j = Jenkins.getInstance();
+        PerItemDatabaseConfiguration pidbc = j.getExtensionList(GlobalConfiguration.class).get(PerItemDatabaseConfiguration.class);
+        if (pidbc != null) {// being defensive
+            if (pidbc.getDatabase() == null)
+                pidbc.setDatabase(new PerItemH2Database(false));
+        }
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/database/h2/PerItemH2Database.java
+++ b/src/main/java/org/jenkinsci/plugins/database/h2/PerItemH2Database.java
@@ -17,7 +17,15 @@ public class PerItemH2Database extends PerItemDatabase  {
     // XXX should also discard entry if ItemListener.onDeleted/Renamed
     private transient Map<TopLevelItem,DataSource> sources;
 
-    @DataBoundConstructor public PerItemH2Database() {}
+    private final boolean autoServer;
+
+    @DataBoundConstructor public PerItemH2Database(boolean autoServer) {
+        this.autoServer = autoServer;
+    }
+
+    public boolean getAutoServer(){
+        return this.autoServer;
+    }
 
     @Override public DataSource getDataSource(TopLevelItem item) throws SQLException {
         if (sources == null) {
@@ -27,7 +35,11 @@ public class PerItemH2Database extends PerItemDatabase  {
         if (source == null) {
             BasicDataSource2 fac = new BasicDataSource2();
             fac.setDriverClass(Driver.class);
-            fac.setUrl("jdbc:h2:" + item.getRootDir().toURI() + "data");
+            String url = "jdbc:h2:" + item.getRootDir().toURI() + "data";
+            if(this.autoServer){
+                url += ";AUTO_SERVER=true";
+            }
+            fac.setUrl(url);
             source = fac.createDataSource();
             sources.put(item, source); // XXX consider closing and discarding after some timeout
         }

--- a/src/main/resources/org/jenkinsci/plugins/database/h2/LocalH2Database/help-autoServer.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/h2/LocalH2Database/help-autoServer.html
@@ -1,0 +1,5 @@
+<div>
+    With Automatic Mixed Mode multiple processes can access the same database without having to start the server
+    manually.
+    For more information see <a href="http://www.h2database.com/html/features.html#auto_mixed_mode">H2 documentation</a>.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/database/h2/LocalH2Database/help-path.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/h2/LocalH2Database/help-path.html
@@ -1,3 +1,3 @@
 <div>
-    Specifies the directory on Jenkins masterin which the H2 database is stored.
+    Specifies the directory on Jenkins master in which the H2 database is stored.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/config.groovy
@@ -1,10 +1,6 @@
-package org.jenkinsci.plugins.database.h2.LocalH2Database
+package org.jenkinsci.plugins.database.h2.PerItemH2Database
 
 def f = namespace(lib.FormTagLib)
-
-f.entry(field:"path",title:_("File Path")) {
-    f.textbox()
-}
 f.advanced(){
     f.entry(field:"autoServer",title:_("Use Automatic Mixed Mode")) {
         f.checkbox()

--- a/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/help-autoServer.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/help-autoServer.html
@@ -1,0 +1,5 @@
+<div>
+    With Automatic Mixed Mode multiple processes can access the same database without having to start the server
+    manually.
+    For more information see <a href="http://www.h2database.com/html/features.html#auto_mixed_mode">H2 documentation</a>.
+</div>


### PR DESCRIPTION
Sometimes it's quite handy to connect to a embedded H2 database from multiple processes (e.g. for debugging purposes during plugin development).

For more information on Automatic Mixed mode see http://www.h2database.com/html/features.html#auto_mixed_mode

