### PR TITLE
Provide configuration option to use H2's Automatic Mixed Mode.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/database/h2/PerItemH2Database.java
+++ b/src/main/java/org/jenkinsci/plugins/database/h2/PerItemH2Database.java
@@ -1,23 +1,32 @@
 package org.jenkinsci.plugins.database.h2;
 
 import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.TopLevelItem;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.WeakHashMap;
 import javax.sql.DataSource;
+
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import org.h2.Driver;
 import org.jenkinsci.plugins.database.BasicDataSource2;
 import org.jenkinsci.plugins.database.PerItemDatabase;
+import org.jenkinsci.plugins.database.PerItemDatabaseConfiguration;
 import org.jenkinsci.plugins.database.PerItemDatabaseDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class PerItemH2Database extends PerItemDatabase  {
-    
+    private final boolean autoServer;
+
     // XXX should also discard entry if ItemListener.onDeleted/Renamed
     private transient Map<TopLevelItem,DataSource> sources;
 
-    @DataBoundConstructor public PerItemH2Database() {}
+    @DataBoundConstructor public PerItemH2Database(boolean autoServer) {
+        this.autoServer = autoServer;
+    }
 
     @Override public DataSource getDataSource(TopLevelItem item) throws SQLException {
         if (sources == null) {
@@ -27,11 +36,22 @@ public class PerItemH2Database extends PerItemDatabase  {
         if (source == null) {
             BasicDataSource2 fac = new BasicDataSource2();
             fac.setDriverClass(Driver.class);
-            fac.setUrl("jdbc:h2:" + item.getRootDir().toURI() + "data");
+            fac.setUrl(appendUrlParameters("jdbc:h2:" + item.getRootDir().toURI() + "data"));
             source = fac.createDataSource();
             sources.put(item, source); // XXX consider closing and discarding after some timeout
         }
         return source;
+    }
+
+    private String appendUrlParameters(String url) {
+        if (getAutoServer()) {
+            url += ";AUTO_SERVER=true";
+        }
+        return url;
+    }
+
+    public boolean getAutoServer() {
+        return this.autoServer;
     }
 
     @Extension public static class DescriptorImpl extends PerItemDatabaseDescriptor {
@@ -40,6 +60,16 @@ public class PerItemH2Database extends PerItemDatabase  {
             return "Embedded local database (H2)";
         }
 
+    }
+
+    @Initializer(after = InitMilestone.PLUGINS_STARTED)
+    public static void setDefaultPerItemDatabase() {
+        Jenkins j = Jenkins.getInstance();
+        PerItemDatabaseConfiguration pidbc = j.getExtensionList(GlobalConfiguration.class).get(PerItemDatabaseConfiguration.class);
+        if (pidbc != null) {// being defensive
+            if (pidbc.getDatabase() == null)
+                pidbc.setDatabase(new PerItemH2Database(false));
+        }
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/database/h2/LocalH2Database/help-autoServer.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/h2/LocalH2Database/help-autoServer.html
@@ -1,0 +1,5 @@
+<div>
+    With Automatic Mixed Mode multiple processes can access the same database without having to start the server
+    manually.
+    For more information see <a href="http://www.h2database.com/html/features.html#auto_mixed_mode">H2 documentation</a>.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/config.groovy
@@ -1,10 +1,7 @@
-package org.jenkinsci.plugins.database.h2.LocalH2Database
+package org.jenkinsci.plugins.database.h2.PerItemH2Database
 
 def f = namespace(lib.FormTagLib)
 
-f.entry(field:"path",title:_("File Path")) {
-    f.textbox()
-}
 f.advanced() {
     f.entry(field:"autoServer",title:_("Use Automatic Mixed Mode")) {
         f.checkbox()

--- a/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/help-autoServer.html
+++ b/src/main/resources/org/jenkinsci/plugins/database/h2/PerItemH2Database/help-autoServer.html
@@ -1,0 +1,5 @@
+<div>
+    With Automatic Mixed Mode multiple processes can access the same database without having to start the server
+    manually.
+    For more information see <a href="http://www.h2database.com/html/features.html#auto_mixed_mode">H2 documentation</a>.
+</div>


### PR DESCRIPTION
Sometimes it's quite handy to connect to an embedded H2 database from multiple processes (e.g. for debugging purposes during plugin development). For more information on Automatic Mixed mode see http://www.h2database.com/html/features.html#auto_mixed_mode